### PR TITLE
Adding big query usage tracking template

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ If you have content that could benefit the wider Lightdash community, please fee
 
 ## How to
 
-This repo is organized by data type or domain (e.g., Google BigQuery tracking). Each folder contains specific instructions, but here’s the gist:
+This repo is organized by data type or domain (e.g., bigquery-usage-tracking). Each folder contains specific instructions, but here’s the gist:
 
 1. **Navigate** to the relevant folder (e.g., *BigQuery*) and review the included charts/dashboards. 📂
 2. **Copy** the yml files into a `lightdash` folder in the root of your dbt project. 📑
-3. If needed, **create** new dbt models/yml files for the underlying data—BigQuery, for example, may require `information_schema.jobs`. _Tip - `lightdash generate` will save you time here!_ ✨
+3. If needed, **create** new dbt models/yml files for the underlying data. BigQuery, for example, may require a model pointed at `information_schema.jobs`. _Tip - `lightdash generate` will save you time here!_ ✨
 4. **Adjust** the content yml references to point to your own tables. ⚙️
 5. Finally, **run** `lightdash upload --force` to immediately push your new content to Lightdash. 🚀
 

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-big-query-costs.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-big-query-costs.yml
@@ -1,0 +1,101 @@
+name: Big Query Costs
+description: >-
+  Shows the total unique jobs ran by BigQuery, and the number of GBs scanned by
+  those jobs.
+tableName: big_query_jobs
+updatedAt: "2025-01-01T00:00:00.000Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_creation_time_week
+  metrics:
+    - big_query_jobs_total_bytes_processed_total_bytes_billed
+  filters:
+    dimensions:
+      id: 1885ca54-f56e-4c23-8a1c-590171d7e7d4
+      and:
+        - id: 9c70204e-48c3-4f5e-8a5e-0c7890e5190c
+          target:
+            fieldId: big_query_jobs_creation_time_day
+          values:
+            - 0
+          operator: notInTheCurrent
+          required: false
+          settings:
+            completed: false
+            unitOfTime: days
+  sorts:
+    - fieldId: big_query_jobs_creation_time_week
+      descending: true
+  limit: 500
+  metricOverrides: {}
+  tableCalculations:
+    - name: cost
+      displayName: Cost
+      sql: >-
+        (${big_query_jobs.total_bytes_processed_total_bytes_billed}/1000000000000)
+        * 6.5
+      format:
+        type: currency
+        currency: USD
+        separator: default
+      type: number
+  additionalMetrics:
+    - name: job_id_count_of_jobs
+      label: Count of Jobs
+      description: "Count distinct of Job id on the table Big query costs "
+      sql: ${TABLE}.job_id
+      table: big_query_jobs
+      type: count_distinct
+      baseDimensionName: job_id
+      formatOptions:
+        type: default
+        separator: default
+    - name: total_bytes_processed_total_bytes_billed
+      label: Total bytes billed
+      description: "Sum of Total bytes processed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_processed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_processed
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: cartesian
+  config:
+    layout:
+      xField: big_query_jobs_creation_time_week
+      yField:
+        - cost
+      flipAxes: false
+      showGridX: false
+    eChartsConfig:
+      yAxis:
+        - name: ""
+        - name: ""
+      legend:
+        show: false
+        type: plain
+        orient: horizontal
+      series:
+        - type: bar
+          label:
+            show: true
+            position: top
+          encode:
+            xRef:
+              field: big_query_jobs_creation_time_week
+            yRef:
+              field: cost
+          yAxisIndex: 0
+dashboardSlug: ld-bq-bigquery-usage-tracking
+spaceSlug: templates
+slug: ld-bq-big-query-costs
+tableConfig:
+  columnOrder:
+    - big_query_jobs_creation_time_week
+    - big_query_jobs_total_bytes_processed_total_bytes_billed
+    - cost
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-big-query-usage.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-big-query-usage.yml
@@ -1,0 +1,107 @@
+name: Big Query Usage
+description: >-
+  Shows the total unique jobs ran by BigQuery, and the number of GiBs scanned by
+  those jobs.
+tableName: big_query_jobs
+updatedAt: "2025-01-10T14:40:22.220Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_creation_time_day
+  metrics:
+    - big_query_jobs_job_id_count_of_jobs
+    - big_query_jobs_total_bytes_processed_total_bytes_billed
+  filters:
+    dimensions:
+      id: b5fd4ff3-be33-485b-92ae-f1d4bad5750d
+      and:
+        - id: 9c70204e-48c3-4f5e-8a5e-0c7890e5190c
+          target:
+            fieldId: big_query_jobs_creation_time_day
+          values:
+            - 0
+          operator: notInTheCurrent
+          required: false
+          settings:
+            completed: false
+            unitOfTime: days
+  sorts:
+    - fieldId: big_query_jobs_creation_time_day
+      descending: true
+  limit: 500
+  metricOverrides: {}
+  tableCalculations:
+    - name: billed_gi_b
+      displayName: Billed GiB
+      sql: ${big_query_jobs.total_bytes_processed_total_bytes_billed}/1000000000
+      format:
+        type: number
+        round: 0
+        currency: USD
+        separator: default
+      type: number
+  additionalMetrics:
+    - name: job_id_count_of_jobs
+      label: Count of Jobs
+      description: "Count distinct of Job id on the table Big query costs "
+      sql: ${TABLE}.job_id
+      table: big_query_jobs
+      type: count_distinct
+      baseDimensionName: job_id
+      formatOptions:
+        type: default
+        separator: default
+    - name: total_bytes_processed_total_bytes_billed
+      label: Total bytes billed
+      description: "Sum of Total bytes processed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_processed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_processed
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: cartesian
+  config:
+    layout:
+      xField: big_query_jobs_creation_time_day
+      yField:
+        - big_query_jobs_job_id_count_of_jobs
+        - billed_gi_b
+      showGridX: false
+    eChartsConfig:
+      yAxis:
+        - name: Jobs
+        - name: Gigabytes
+      legend:
+        show: true
+        type: plain
+        orient: horizontal
+      series:
+        - type: line
+          color: "#7262FF"
+          encode:
+            xRef:
+              field: big_query_jobs_creation_time_day
+            yRef:
+              field: big_query_jobs_job_id_count_of_jobs
+          yAxisIndex: 0
+        - type: bar
+          encode:
+            xRef:
+              field: big_query_jobs_creation_time_day
+            yRef:
+              field: billed_gi_b
+          yAxisIndex: 1
+dashboardSlug: ld-bq-bigquery-usage-tracking
+spaceSlug: templates
+slug: ld-bq-big-query-usage
+tableConfig:
+  columnOrder:
+    - big_query_jobs_creation_time_day
+    - big_query_jobs_job_id_count_of_jobs
+    - big_query_jobs_total_bytes_processed_total_bytes_billed
+    - billed_gi_b
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-billed-gib-by-statement-type.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-billed-gib-by-statement-type.yml
@@ -1,0 +1,97 @@
+name: Billed GiB by Statement Type
+description: >-
+  Shows the count of Billed GiB split by different statement types in Big
+  Query. 
+tableName: big_query_jobs
+updatedAt: "2025-01-01T00:00:00.000Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_statement_type
+  metrics:
+    - big_query_jobs_total_bytes_billed_sum_of_total_bytes_billed
+  filters:
+    metrics:
+      id: 83c23b38-7828-4298-b6b2-b5c4128e15d6
+      and:
+        - id: 981ec49b-5192-4f1f-aef6-51eb1dd21cb5
+          target:
+            fieldId: big_query_jobs_total_bytes_billed_billed_g_b
+          values:
+            - 0
+          operator: greaterThan
+  sorts:
+    - fieldId: big_query_jobs_statement_type
+      descending: false
+  limit: 500
+  metricOverrides: {}
+  tableCalculations:
+    - name: billed_gi_b
+      displayName: Billed GiB
+      sql: >-
+        ${big_query_jobs.total_bytes_billed_sum_of_total_bytes_billed}/1000000000
+      format:
+        type: number
+        round: 0
+        currency: USD
+        separator: default
+      type: number
+  additionalMetrics:
+    - name: job_id_count_distinct_of_job_id
+      label: Count distinct of Job id
+      description: "Count distinct of Job id on the table Big query costs "
+      sql: ${TABLE}.job_id
+      table: big_query_jobs
+      type: count_distinct
+      baseDimensionName: job_id
+      formatOptions:
+        type: default
+        separator: default
+    - name: total_bytes_billed_billed_g_b
+      label: Billed GB
+      description: "Sum of Total bytes billed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_billed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_billed
+      formatOptions:
+        type: number
+        round: 0
+        separator: default
+    - name: total_bytes_billed_sum_of_total_bytes_billed
+      label: Sum of Total bytes billed
+      description: "Sum of Total bytes billed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_billed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_billed
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: pie
+  config:
+    isDonut: true
+    metricId: billed_gi_b
+    showValue: false
+    showLegend: true
+    valueLabel: hidden
+    groupFieldIds:
+      - big_query_jobs_statement_type
+    legendPosition: horizontal
+    showPercentage: true
+    groupSortOverrides: []
+    groupColorOverrides: {}
+    groupLabelOverrides: {}
+    legendMaxItemLength: 30
+    groupValueOptionOverrides: {}
+dashboardSlug: ld-bq-bigquery-usage-tracking
+spaceSlug: templates
+slug: ld-bq-billed-gib-by-statement-type
+tableConfig:
+  columnOrder:
+    - big_query_jobs_statement_type
+    - big_query_jobs_total_bytes_billed_sum_of_total_bytes_billed
+    - billed_gi_b
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-billed-gib.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-billed-gib.yml
@@ -1,0 +1,72 @@
+name: Billed GiB
+description: >-
+  Shows the Billed GiB for the latest completed month and compares the month
+  previous
+tableName: big_query_jobs
+updatedAt: "2025-01-01T00:00:00.000Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_creation_time_month
+  metrics:
+    - big_query_jobs_total_bytes_billed_total_bytes_billed
+  filters:
+    dimensions:
+      id: 03932f84-152b-4b17-bda6-cd7664337efa
+      and:
+        - id: aba9f6d1-002d-4143-960b-6fb6a0518c19
+          target:
+            fieldId: big_query_jobs_creation_time_month
+          values:
+            - 1
+          operator: notInTheCurrent
+          required: false
+          settings:
+            completed: false
+            unitOfTime: months
+  sorts:
+    - fieldId: big_query_jobs_creation_time_month
+      descending: true
+  limit: 500
+  metricOverrides: {}
+  tableCalculations:
+    - name: billed_gi_b_1
+      displayName: Billed GiB
+      sql: (${big_query_jobs.total_bytes_billed_total_bytes_billed}/ 1000000000)
+      format:
+        type: number
+        round: 0
+        currency: USD
+        separator: default
+      type: number
+  additionalMetrics:
+    - name: total_bytes_billed_total_bytes_billed
+      label: Total bytes billed
+      description: "Sum of Total bytes billed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_billed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_billed
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: big_number
+  config:
+    label: Latest Completed Month Billed GiB
+    flipColors: true
+    selectedField: billed_gi_b_1
+    showComparison: true
+    comparisonLabel: Previous Month
+    comparisonFormat: raw
+    showBigNumberLabel: true
+dashboardSlug: ld-bq-bigquery-usage-tracking
+spaceSlug: templates
+slug: ld-bq-billed-gib
+tableConfig:
+  columnOrder:
+    - big_query_jobs_creation_time_month
+    - big_query_jobs_total_bytes_billed_total_bytes_billed
+    - billed_gi_b_1
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-cost.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-cost.yml
@@ -1,0 +1,74 @@
+name: Cost
+description: >-
+  Shows the incurred cost for the latest completed month and compares the month
+  previous
+tableName: big_query_jobs
+updatedAt: "2025-01-01T00:00:00.000Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_creation_time_month
+  metrics:
+    - big_query_jobs_total_bytes_billed_total_bytes_billed
+  filters:
+    dimensions:
+      id: b483aa61-de6a-44b6-b913-12a84bdd85c5
+      and:
+        - id: 686a25d2-6053-40f7-9143-68c3aa386f3d
+          target:
+            fieldId: big_query_jobs_creation_time_month
+          values:
+            - 1
+          operator: notInTheCurrent
+          required: false
+          settings:
+            completed: false
+            unitOfTime: months
+  sorts:
+    - fieldId: big_query_jobs_creation_time_month
+      descending: true
+  limit: 500
+  metricOverrides: {}
+  tableCalculations:
+    - name: total_cost
+      displayName: Total Cost
+      sql: >-
+        (${big_query_jobs.total_bytes_billed_total_bytes_billed}/
+        1000000000000) * 6.25
+      format:
+        type: currency
+        round: 2
+        currency: USD
+        separator: default
+      type: number
+  additionalMetrics:
+    - name: total_bytes_billed_total_bytes_billed
+      label: Total bytes billed
+      description: "Sum of Total bytes billed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_billed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_billed
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: big_number
+  config:
+    label: Latest Completed Month Compute Cost
+    flipColors: true
+    selectedField: total_cost
+    showComparison: true
+    comparisonLabel: Previous Month
+    comparisonFormat: raw
+    showBigNumberLabel: true
+dashboardSlug: ld-bq-bigquery-usage-tracking
+spaceSlug: templates
+slug: ld-bq-cost
+tableConfig:
+  columnOrder:
+    - big_query_jobs_creation_time_month
+    - big_query_jobs_total_bytes_billed_total_bytes_billed
+    - total_cost
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-jobs-by-statement-type.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-jobs-by-statement-type.yml
@@ -1,0 +1,54 @@
+name: Jobs by Statement Type
+description: "Shows the count of jobs split by different statement types in Big Query. "
+tableName: big_query_jobs
+updatedAt: "2025-01-01T00:00:00.000Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_statement_type
+  metrics:
+    - big_query_jobs_job_id_count_distinct_of_job_id
+  filters: {}
+  sorts:
+    - fieldId: big_query_jobs_statement_type
+      descending: false
+  limit: 500
+  metricOverrides: {}
+  tableCalculations: []
+  additionalMetrics:
+    - name: job_id_count_distinct_of_job_id
+      label: Count distinct of Job id
+      description: "Count distinct of Job id on the table Big query costs "
+      sql: ${TABLE}.job_id
+      table: big_query_jobs
+      type: count_distinct
+      baseDimensionName: job_id
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: pie
+  config:
+    isDonut: true
+    metricId: big_query_jobs_job_id_count_distinct_of_job_id
+    showValue: false
+    showLegend: true
+    valueLabel: hidden
+    groupFieldIds:
+      - big_query_jobs_statement_type
+    legendPosition: horizontal
+    showPercentage: true
+    groupSortOverrides: []
+    groupColorOverrides: {}
+    groupLabelOverrides: {}
+    legendMaxItemLength: 30
+    groupValueOptionOverrides: {}
+dashboardSlug: ld-bq-bigquery-usage-tracking
+spaceSlug: templates
+slug: ld-bq-jobs-by-statement-type
+tableConfig:
+  columnOrder:
+    - big_query_jobs_statement_type
+    - big_query_jobs_job_id_count_distinct_of_job_id
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-jobs-ran.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-jobs-ran.yml
@@ -1,0 +1,72 @@
+name: Jobs Ran
+description: >-
+  Shows the total number of jobs ran for the latest completed month and compares
+  the month previous
+tableName: big_query_jobs
+updatedAt: "2025-01-01T00:00:00.000Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_creation_time_month
+  metrics:
+    - big_query_jobs_job_id_total_jobs
+  filters:
+    dimensions:
+      id: 60317ac1-5505-4dd1-89f6-d9cf53c11a52
+      and:
+        - id: 5ef319b5-d4c9-430a-8e63-4989d9a4eea9
+          target:
+            fieldId: big_query_jobs_creation_time_month
+          values:
+            - 1
+          operator: notInTheCurrent
+          required: false
+          settings:
+            completed: false
+            unitOfTime: months
+  sorts:
+    - fieldId: big_query_jobs_creation_time_month
+      descending: true
+  limit: 500
+  metricOverrides: {}
+  tableCalculations: []
+  additionalMetrics:
+    - name: total_bytes_billed_total_bytes_billed
+      label: Total bytes billed
+      description: "Sum of Total bytes billed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_billed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_billed
+      formatOptions:
+        type: default
+        separator: default
+    - name: job_id_total_jobs
+      label: Total Jobs
+      description: "Count distinct of Job id on the table Big query costs "
+      sql: ${TABLE}.job_id
+      table: big_query_jobs
+      type: count_distinct
+      baseDimensionName: job_id
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: big_number
+  config:
+    label: Latest Completed Month Jobs Ran
+    flipColors: false
+    selectedField: big_query_jobs_job_id_total_jobs
+    showComparison: true
+    comparisonLabel: Previous Month
+    comparisonFormat: raw
+    showBigNumberLabel: true
+dashboardSlug: ld-bq-bigquery-usage-tracking
+spaceSlug: templates
+slug: ld-bq-jobs-ran
+tableConfig:
+  columnOrder:
+    - big_query_jobs_creation_time_month
+    - big_query_jobs_job_id_total_jobs
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-top-users.yml
+++ b/templates/bigquery-usage-tracking/lightdash/charts/ld-bq-top-users.yml
@@ -1,0 +1,90 @@
+name: Top Users
+description: The top 50 BigQuery users by email, ordered by their total GiB billed
+tableName: big_query_jobs
+updatedAt: "2025-01-01T00:00:00.000Z"
+metricQuery:
+  exploreName: big_query_jobs
+  dimensions:
+    - big_query_jobs_user_email
+  metrics:
+    - big_query_jobs_total_bytes_billed_total_bytes_billed
+    - big_query_jobs_job_id_count_of_jobs
+  filters: {}
+  sorts:
+    - fieldId: big_query_jobs_total_bytes_billed_total_bytes_billed
+      descending: true
+  limit: 50
+  metricOverrides: {}
+  tableCalculations:
+    - name: total_gi_b_billed
+      displayName: Total GiB billed
+      sql: ${big_query_jobs.total_bytes_billed_total_bytes_billed} / 1000000000
+      format:
+        type: number
+        round: 0
+        separator: default
+      type: number
+    - name: total_cost
+      displayName: Total Cost
+      sql: >-
+        (${big_query_jobs.total_bytes_billed_total_bytes_billed} /
+        1000000000000) * 6.25
+      format:
+        type: currency
+        currency: USD
+        separator: default
+      type: number
+  additionalMetrics:
+    - name: total_bytes_billed_total_bytes_billed
+      label: Total bytes billed
+      description: "Sum of Total bytes billed on the table Big query costs "
+      sql: ${TABLE}.total_bytes_billed
+      table: big_query_jobs
+      type: sum
+      baseDimensionName: total_bytes_billed
+      formatOptions:
+        type: default
+        separator: default
+    - name: job_id_count_of_jobs
+      label: Count of Jobs
+      description: "Count distinct of Job id on the table Big query costs "
+      sql: ${TABLE}.job_id
+      table: big_query_jobs
+      type: count_distinct
+      baseDimensionName: job_id
+      formatOptions:
+        type: default
+        separator: default
+  customDimensions: []
+chartConfig:
+  type: table
+  config:
+    columns:
+      big_query_jobs_total_bytes_billed_total_bytes_billed:
+        visible: false
+    metricsAsRows: false
+    showSubtotals: false
+    hideRowNumbers: false
+    showTableNames: false
+    showResultsTotal: false
+    showRowCalculation: false
+    showColumnCalculation: false
+    conditionalFormattings:
+      - color: "#7262FF"
+        rules:
+          - id: 78575e4f-2db7-41f2-9959-db9f92a0133f
+            values: []
+            operator: equals
+        target:
+          fieldId: big_query_jobs_total_bytes_billed_total_bytes_billed
+dashboardSlug: ld-bq-bigquery-usage-tracking
+slug: ld-bq-top-users
+spaceSlug: templates
+tableConfig:
+  columnOrder:
+    - big_query_jobs_user_email
+    - big_query_jobs_total_bytes_billed_total_bytes_billed
+    - total_gi_b_billed
+    - total_cost
+    - big_query_jobs_job_id_count_of_jobs
+version: 1

--- a/templates/bigquery-usage-tracking/lightdash/dashboards/ld-bq-bigquery-usage-tracking.yml
+++ b/templates/bigquery-usage-tracking/lightdash/dashboards/ld-bq-bigquery-usage-tracking.yml
@@ -1,0 +1,127 @@
+name: BigQuery Usage Tracking
+description: >-
+  This dashboard is designed to give you an overview of BigQuery usage,
+  including an estimate of total costs.
+updatedAt: "2025-01-01T00:00:00.000Z"
+
+tiles:
+  - x: 0
+    y: 0
+    h: 4
+    w: 18
+    type: markdown
+    properties:
+      title: 📊 Big Query Usage
+      content: >
+        This dashboard is designed to give you an overview of BigQuery usage.
+
+
+        💵 **Costs are estimated and assume a static price per byte billed**.
+        They don't include storage or compute costs. You can find details about
+        BigQuery pricing [here](https://cloud.google.com/bigquery/pricing).
+
+
+        Data is retrieved from the BigQuery information schema, you can find
+        details of the underlying data
+        [here](https://cloud.google.com/bigquery/docs/information-schema-jobs).
+
+  - x: 0
+    y: 12
+    h: 8
+    w: 22
+    type: saved_chart
+    properties:
+      belongsToDashboard: false
+      chartName: Big Query Usage
+      chartSlug: ld-bq-big-query-usage
+      
+  - x: 19
+    y: 4
+    h: 8
+    w: 17
+    type: saved_chart
+    properties:
+      belongsToDashboard: false
+      chartName: Big Query Costs
+      chartSlug: ld-bq-big-query-costs
+
+  - x: 0
+    y: 4
+    h: 8
+    w: 10
+    type: saved_chart
+    properties:
+      belongsToDashboard: true
+      chartName: Jobs by Statement Type
+      chartSlug: ld-bq-jobs-by-statement-type
+
+  - x: 22
+    y: 12
+    h: 8
+    w: 14
+    type: saved_chart
+    properties:
+      belongsToDashboard: true
+      chartName: Top Users
+      chartSlug: ld-bq-top-users
+
+  - x: 18
+    y: 0
+    h: 4
+    w: 6
+    type: saved_chart
+    properties:
+      belongsToDashboard: true
+      chartName: Cost
+      chartSlug: ld-bq-cost
+
+  - x: 30
+    y: 0
+    h: 4
+    w: 6
+    type: saved_chart
+    properties:
+      belongsToDashboard: true
+      chartName: Jobs Ran
+      chartSlug: ld-bq-jobs-ran
+
+  - x: 10
+    y: 4
+    h: 8
+    w: 9
+    type: saved_chart
+    properties:
+      belongsToDashboard: true
+      chartName: Billed GiB by Statement Type
+      chartSlug: ld-bq-billed-gib-by-statement-type
+
+  - x: 24
+    y: 0
+    h: 4
+    w: 6
+    type: saved_chart
+    properties:
+      belongsToDashboard: true
+      chartName: Billed GiB
+      chartSlug: ld-bq-billed-gib
+
+filters:
+  metrics: []
+  dimensions:
+    - id: fbe86450-4f87-4445-94df-513ba88cf8b7 
+      target:
+        fieldId: big_query_jobs_creation_time
+        fieldName: creation_time
+        tableName: big_query_jobs
+      values:
+        - 90
+      operator: inThePast
+      settings:
+        completed: false
+        unitOfTime: days
+  tableCalculations: []
+
+tabs: []
+spaceSlug: templates
+slug: ld-bq-bigquery-usage-tracking
+version: 1

--- a/templates/bigquery-usage-tracking/user_guide.md
+++ b/templates/bigquery-usage-tracking/user_guide.md
@@ -1,0 +1,73 @@
+# BigQuery Template for Lightdash
+
+## Prerequisites
+
+1. **Create a dbt Model**  
+   Ensure you have a dbt model for Lightdash to reference. This template is based on the `information_schema.jobs` table provided by BigQuery.  
+
+   If you don’t already have one, create a `.sql` file in your dbt project named `big_query_jobs.sql` with the following content:
+
+   ```sql
+   {{
+     config(
+       materialized='table'
+     )
+   }}
+
+   select * from `region-us`.`information_schema`.`jobs`
+   ```
+
+   > **Note**: Replace `region-us` with your region. Refer to the [BigQuery documentation](https://cloud.google.com/bigquery/docs/information-schema-jobs) for details.
+
+2. **Generate a YAML File**  
+   Use the Lightdash CLI to generate a YAML file for the BigQuery model:
+   ```bash
+   lightdash generate -s big_query_jobs
+   ```
+
+   Avoid changing any column names for the smoothest experience implementing the template.
+
+   > **Note**: No metrics need to be defined here. Metrics will be created as part of the template.
+
+## Using the Template
+
+Once you have an underlying model that returns your BigQuery jobs information, follow these steps to use the template:
+
+1. **Download the Template**  
+   Download the `lightdash` folder from the relevant section in the `lightdash-templates` repository.
+
+2. **Copy the Template**  
+   Copy the `lightdash` folder into the root of your dbt directory. 
+
+   > If you already have a lightdash content folder in your dbt project, just copy across the charts and dashboards to the relevant folders.
+
+   - *Make the necessary changes to the template* as outlined in the Adjusting the Template section below.
+   
+
+3. **Set Up the Lightdash CLI**  
+   Ensure you are logged into the Lightdash CLI and the correct project is selected using `lightdash config set-project`. This is where your object will be created.
+
+4. **Upload the Template**  
+   Use the following command to upload the BigQuery dashboard and charts:
+   ```bash
+   lightdash upload --force --dashboards ld-bq-bigquery-usage-tracking --charts ld-bq-jobs-ran ld-bq-top-users ld-bq-jobs-by-statement-type ld-bq-cost ld-bq-billed-gib ld-bq-billed-gib-by-statement-type ld-bq-big-query-usage ld-bq-big-query-costs
+   ```
+
+## Adjusting the BigQuery Template
+
+The template consists of a dashboard file and multiple chart files. Before uploading, you need to make the following adjustments:
+
+- Replace commonly changed fields. For BigQuery that usually means the amount charged per TiB of compute, or the currency formatting. The default is 6.5USD per TiB. The following model files can be adjusted to accomodate:
+
+    - `ld-bq-top-users.yml`
+    - `ld-bq-cost.yml`
+    - `ld-bq-big-query-costs.yml`
+
+For each of these files, replace the value `6.5` with whatever your compute per TiB is charged at. You can find docs on this through Google [here](https://cloud.google.com/bigquery/pricing#analysis_pricing_models) 
+
+You can also update the field formatting under this value from `USD` to `GBP` or `EUR` as appropriate.
+
+- **Update column references if you have renamed columns in the BigQuery `information_schema.jobs` model**. Use a find-and-replace tool to update all files.
+
+### Optional Adjustments
+You can customize other settings in the template YAML files, such as default filters. However, it might be easier to make these changes directly in the Lightdash UI.


### PR DESCRIPTION
This PR adds the first set of templates! They enable users to set up Big Query tracking from content-as-code files.